### PR TITLE
feat: add query for group events

### DIFF
--- a/graphql_query.py
+++ b/graphql_query.py
@@ -70,7 +70,7 @@ def query_event(event_id: str):
       }
     }
     """
-    token = auth().get("access_token")
+    token = auth()["access_token"]
     with httpx.Client() as cli:
         response = cli.post(
             "https://api.meetup.com/gql",

--- a/graphql_query.py
+++ b/graphql_query.py
@@ -37,35 +37,39 @@ def auth():
 
 
 def query_event(event_id: str):
-    query = (
-        "query($eventId: ID) {\n"
-        "event(id: $eventId) {\n"
-        "id\n"
-        "title\n"
-        "eventUrl\n"
-        "description\n"
-        "shortDescription\n"
-        "group {\n"
-        "id\n"
-        "name }\n"
-        "isOnline\n"
-        "eventType\n"
-        "venue {\n"
-        "id\n"
-        "name\n"
-        "address\n"
-        "city\n"
-        "postalCode\n"
-        "lng\n"
-        "lat }\n"
-        "onlineVenue {\n"
-        "url }\n"
-        "dateTime\n"
-        "duration\n"
-        "timezone\n"
-        "endTime\n"
-        "}\n}"
-    )
+    query = """
+    query ($eventId: ID) {
+      event(id: $eventId) {
+        id
+        title
+        eventUrl
+        description
+        shortDescription
+        group {
+          id
+          name
+        }
+        isOnline
+        eventType
+        venue {
+          id
+          name
+          address
+          city
+          postalCode
+          lng
+          lat
+        }
+        onlineVenue {
+          url
+        }
+        dateTime
+        duration
+        timezone
+        endTime
+      }
+    }
+    """
     token = auth().get("access_token")
     with httpx.Client() as cli:
         response = cli.post(
@@ -77,3 +81,42 @@ def query_event(event_id: str):
             json={"query": query, "variables": {"eventId": event_id}},
         )
         return response.json()
+
+def query_group_events(urlname: str):
+    query = """
+    query ($urlname: String!) {
+      groupByUrlname(urlname: $urlname) {
+        urlname
+        upcomingEvents(input: {}) {
+          count
+          edges {
+            node {
+              id
+            }
+            cursor
+          }
+        }
+        eventSearch(filter: {query: ""}) {
+          count
+          edges {
+            node {
+              id
+              title
+              dateTime
+            }
+          }
+        }
+      }
+    }"""
+    token = auth().get("access_token")
+    with httpx.Client() as cli:
+        response = cli.post(
+            "https://api.meetup.com/gql",
+            headers={
+                "content_type": "application/json",
+                "authorization": f"Bearer {token}",
+            },
+            json={"query": query, "variables": {"urlname": urlname}},
+        )
+        return response.json()
+

--- a/graphql_query.py
+++ b/graphql_query.py
@@ -108,7 +108,7 @@ def query_group_events(urlname: str):
         }
       }
     }"""
-    token = auth().get("access_token")
+    token = auth()["access_token"]
     with httpx.Client() as cli:
         response = cli.post(
             "https://api.meetup.com/gql",

--- a/graphql_query.py
+++ b/graphql_query.py
@@ -96,16 +96,6 @@ def query_group_events(urlname: str):
             cursor
           }
         }
-        eventSearch(filter: {query: ""}) {
-          count
-          edges {
-            node {
-              id
-              title
-              dateTime
-            }
-          }
-        }
       }
     }"""
     token = auth()["access_token"]


### PR DESCRIPTION
I've finally found Meetup's GraphQL Playground, it's not the best I've seen (the schema doesn't load and you cannot use it outside meetup page, e.g. using the endpoint in https://www.graphqlbin.com/v2/new or other online playgrounds). At least it works to try out the queries.

In the current query both `upcomingEvents` and `eventSearch` fields are request. @astrojuanlu I leave on you the decision on which to use, IMHO we could go for eventSearch so as to enable ourself to define what an upcoming event is. 

Finally, the `node.id` field is the id of the event that will be used later to call `query_event`

Example:
![Screenshot from 2023-04-11 21-15-02](https://user-images.githubusercontent.com/21989518/231269813-20aafc2d-52ec-4791-85df-ce49bb87808b.png)
